### PR TITLE
Fix file extension for .tsx files

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -19,7 +19,7 @@ const config = {
     vscode: 'commonjs vscode'
   },
   resolve: {
-    extensions: ['tsx', '.ts', '.jsx', '.js']
+    extensions: ['.tsx', '.ts', '.jsx', '.js']
   },
   module: {
     rules: [{


### PR DESCRIPTION
Not sure if this has any effect since the loader is only matched on `/\.ts$/`, but might prevent some bugs in the future.